### PR TITLE
Update opBin to use _1password-cli

### DIFF
--- a/modules/op-secrets.nix
+++ b/modules/op-secrets.nix
@@ -15,7 +15,7 @@ in {
   options.opnix = {
     opBin = mkOption {
       type = types.str;
-      default = "${pkgs._1password}/bin/op";
+      default = "${pkgs._1password-cli}/bin/op";
       description = "The 1Password CLI `op` executable to use";
     };
     environmentFile = mkOption {


### PR DESCRIPTION
The `_1password` package was renamed to `_1password-cli` in 24.11.

https://github.com/NixOS/nixpkgs/pull/351281